### PR TITLE
Fix annoying 4996 MSVC warning.

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -761,7 +761,7 @@ inline void InterpretEscSeq(void)
                             case 6:     // ESC[6n Report cursor position
                                     {
                                     WCHAR buf[32];
-                                    swprintf(buf, L"\33[%d;%dR", Info.dwCursorPosition.Y + 1,
+                                    swprintf(buf, 32, L"\33[%d;%dR", Info.dwCursorPosition.Y + 1,
                                         Info.dwCursorPosition.X + 1);
                                     SendSequence(buf);
                                     }


### PR DESCRIPTION
Now swprintf call follows ISO C standard (with 2nd argument - size of buffer).
See http://en.cppreference.com/w/cpp/io/c/fwprintf