### PR TITLE
Get cpp-linenoise to work with clang

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -1826,7 +1826,7 @@ inline int completeLine(struct linenoiseState *ls, char *cbuf, int *c) {
 }
 
 /* Register a callback function to be called for tab-completion. */
-static void SetCompletionCallback(CompletionCallback fn) {
+inline void SetCompletionCallback(CompletionCallback fn) {
     completionCallback = fn;
 }
 

--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -1826,7 +1826,7 @@ inline int completeLine(struct linenoiseState *ls, char *cbuf, int *c) {
 }
 
 /* Register a callback function to be called for tab-completion. */
-void SetCompletionCallback(CompletionCallback fn) {
+static void SetCompletionCallback(CompletionCallback fn) {
     completionCallback = fn;
 }
 

--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -2147,7 +2147,7 @@ inline int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, int buflen, con
 
         switch(c) {
         case ENTER:    /* enter */
-            history.pop_back();
+            if (!history.empty()) history.pop_back();
             if (mlmode) linenoiseEditMoveEnd(&l);
             return (int)l.len;
         case CTRL_C:     /* ctrl-c */


### PR DESCRIPTION
Hey,

I've just switched from readline to cpp-linenoise and fixed to small problems I ran into.
The function i declared static resulted in a linker error:

`CMakeFiles/sinksh.dir/repl/replStates.cpp.o: In function `qt_noop()':
/src/sink/sinksh/repl/linenoise.hpp:1830: multiple definition of `linenoise::SetCompletionCallback(std::function<void (char const*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)>)'
CMakeFiles/sinksh.dir/repl/repl.cpp.o:/src/sink/sinksh/repl/linenoise.hpp:1830: first defined here
clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [sinksh/CMakeFiles/sinksh.dir/build.make:694: sinksh/sinksh] Error 1
make[1]: *** [CMakeFiles/Makefile2:4345: sinksh/CMakeFiles/sinksh.dir/all] Error 2
`
I guess because I included the file from two cpp files in the project.

Cheers!