### PR TITLE
Fix msvc error

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -755,7 +755,7 @@ inline void InterpretEscSeq(void)
                     switch (es_argv[0])
                         {
                             case 5:     // ESC[5n Report status
-                                SendSequence(L"\33[0n"); // "OK"
+                                SendSequence((LPWSTR)L"\33[0n"); // "OK"
                                 return;
 
                             case 6:     // ESC[6n Report cursor position


### PR DESCRIPTION
This fixes following error:
```
linenoise.hpp(758): error C2664: 'void linenoise::ansi::SendSequence(LPWSTR)': cannot convert argument 1 from 'const wchar_t [5]' to 'LPWSTR'
```