### PR TITLE
Fix Ctrl-C handling on Windows

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -1646,7 +1646,8 @@ inline bool enableRawMode(int fd) {
     }
 
     GetConsoleMode(hIn, &consolemodeIn);
-    SetConsoleMode(hIn, ENABLE_PROCESSED_INPUT);
+    DWORD consolemodeInWithRaw = consolemodeIn & ~ENABLE_PROCESSED_INPUT;
+    SetConsoleMode(hIn, consolemodeInWithRaw);
 
     rawmode = true;
 #endif


### PR DESCRIPTION
The previous version of the code would overwrite the console mode with `ENABLE_PROCESSED_INPUT` to try and enable raw input mode. However, `ENABLE_PROCESSED_INPUT` does the opposite: If enabled, "CTRL+C is processed by the system and is not placed in the input buffer" (https://docs.microsoft.com/en-us/windows/console/setconsolemode). Therefore, that flag must be masked out instead.

Additionally, this patch fixes cpp-linenoise overwriting all current console mode flags. This prevented users of this library from possibly working with `ENABLE_VIRTUAL_TERMINAL_PROCESSING` and other things.