### PR TITLE
Remove duplicate header include.

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -147,7 +147,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#include <stdlib.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include <string>


### PR DESCRIPTION
Hey! Thanks for the great library :)

I noticed there was a duplicate include of `stdlib.h`, this patch removes the duplicate.