### PR TITLE
Fix spelling in comment.

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -1611,7 +1611,7 @@ inline bool enableRawMode(int fd) {
     // raw.c_oflag &= ~(OPOST);
     /* control modes - set 8 bit chars */
     raw.c_cflag |= (CS8);
-    /* local modes - choing off, canonical off, no extended functions,
+    /* local modes - echoing off, canonical off, no extended functions,
      * no signal chars (^Z,^C) */
     raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
     /* control chars - set return condition: min number of bytes and timer.


### PR DESCRIPTION
The word `echoing` was missing an `e`.