### PR TITLE
Jump across initialized variable

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -1648,8 +1648,8 @@ inline bool enableRawMode(int fd) {
     }
 
     GetConsoleMode(hIn, &consolemodeIn);
-    DWORD consolemodeInWithRaw = consolemodeIn & ~ENABLE_PROCESSED_INPUT;
-    SetConsoleMode(hIn, consolemodeInWithRaw);
+    /* Enable raw mode */
+    SetConsoleMode(hIn, consolemodeIn & ~ENABLE_PROCESSED_INPUT);
 
     rawmode = true;
 #endif


### PR DESCRIPTION
Eliminate a compiler warning caused by goto fatal jump over the initialized variable consolemodeInWithRaw. Produced in clang-cl as the "microsoft-goto" warning.