### PR TITLE
Fix DEL key behavior on Windows

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -1025,7 +1025,7 @@ inline int win32read(int *c) {
                         *c = 8;
                         return 1;
                     case VK_DELETE:
-                        *c = 127;
+                        *c = 4; /* same as Ctrl+D above */
                         return 1;
                     default:
                         if (*c) return 1;


### PR DESCRIPTION
Before this, VK_DELETE was mapped to 127 which is treated as a back space character by the cross-platform key handling code.

Instead this should map to Ctrl+D (4) which deletes the character under cursor.