### PR TITLE
Don't hide previous declaration of `len`

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -777,7 +777,7 @@ inline void InterpretEscSeq(void)
                     if (es_argv[0] == 21)   // ESC[21t Report xterm window's title
                         {
                         WCHAR buf[MAX_PATH * 2];
-                        DWORD len = GetConsoleTitleW(buf + 3, lenof(buf) - 3 - 2);
+                        len = GetConsoleTitleW(buf + 3, lenof(buf) - 3 - 2);
                         // Too bad if it's too big or fails.
                         buf[0] = ESC;
                         buf[1] = ']';


### PR DESCRIPTION
Don't re-declare `len`, use the variable declared at the beginning of the function. 

On Windows MSVC emits a warning for this:

linenoise.hpp(780): warning C4456: declaration of 'len' hides previous local declaration
linenoise.hpp(378): note: see declaration of 'len'